### PR TITLE
Adds scraping of data-src attributes

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,8 +210,12 @@ func getScriptSrc(url string) ([]string, error) {
 	// Find the script tags, and get the src
 	doc.Find("script").Each(func(i int, s *goquery.Selection) {
 		src, _ := s.Attr("src")
+		dsrc, _ := s.Attr("data-src")
 		if src != "" {
 			sources = append(sources, src)
+		}
+		if dsrc != "" {
+			sources = append(sources, dsrc)
 		}
 	})
 


### PR DESCRIPTION
Hey @003random ,

As per my observation , `data-src` attributes within the `<script>` tag can also reference a `.js` file. I am new to golang and have been fiddling with a few tools to my liking. 

Let me know what you think of this.

Regards